### PR TITLE
fix: `esModule` option should defaults to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ By default, `@rsbuild/plugin-toml` generates JS modules that use the ES modules 
 
 ```js
 pluginToml({
-  exModule: false,
+  esModule: false,
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export const pluginToml = (options: PluginTomlOptions = {}): RsbuildPlugin => ({
 
 	async setup(api) {
 		const { parse } = await import('toml');
-		const { esModule } = options;
+		const { esModule = true } = options;
 
 		api.transform({ test: /\.toml$/ }, ({ code }) => {
 			const parsed = parse(code);


### PR DESCRIPTION
The `esModule` option should defaults to `true` to be consistent with the documentation.