### PR TITLE
feat!: pure ESM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,64 +1,59 @@
 {
-  "name": "@rsbuild/plugin-toml",
-  "version": "1.1.2",
-  "repository": "https://github.com/rstackjs/rsbuild-plugin-toml",
-  "license": "MIT",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
-    }
-  },
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "rslib",
-    "dev": "rslib -w",
-    "lint": "biome check .",
-    "lint:write": "biome check . --write",
-    "prepare": "simple-git-hooks && npm run build",
-    "test": "playwright test",
-    "bump": "npx bumpp"
-  },
-  "simple-git-hooks": {
-    "pre-commit": "npx nano-staged"
-  },
-  "nano-staged": {
-    "*.{js,jsx,ts,tsx,mjs,cjs}": [
-      "biome check --write --no-errors-on-unmatched"
-    ]
-  },
-  "dependencies": {
-    "toml": "^4.1.1"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "^1.9.4",
-    "@playwright/test": "^1.59.1",
-    "@rsbuild/core": "1.7.5",
-    "@rslib/core": "^0.21.2",
-    "@types/node": "^24.12.2",
-    "nano-staged": "^1.0.2",
-    "playwright": "^1.59.1",
-    "simple-git-hooks": "^2.13.1",
-    "typescript": "^6.0.3"
-  },
-  "peerDependencies": {
-    "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
-  },
-  "peerDependenciesMeta": {
-    "@rsbuild/core": {
-      "optional": true
-    }
-  },
-  "packageManager": "pnpm@10.33.0",
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  }
+	"name": "@rsbuild/plugin-toml",
+	"version": "1.1.2",
+	"repository": "https://github.com/rstackjs/rsbuild-plugin-toml",
+	"license": "MIT",
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		}
+	},
+	"types": "./dist/index.d.ts",
+	"files": ["dist"],
+	"scripts": {
+		"build": "rslib",
+		"dev": "rslib -w",
+		"lint": "biome check .",
+		"lint:write": "biome check . --write",
+		"prepare": "simple-git-hooks && npm run build",
+		"test": "playwright test",
+		"bump": "npx bumpp"
+	},
+	"simple-git-hooks": {
+		"pre-commit": "npx nano-staged"
+	},
+	"nano-staged": {
+		"*.{js,jsx,ts,tsx,mjs,cjs}": [
+			"biome check --write --no-errors-on-unmatched"
+		]
+	},
+	"dependencies": {
+		"toml": "^4.1.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^1.9.4",
+		"@playwright/test": "^1.59.1",
+		"@rsbuild/core": "1.7.5",
+		"@rslib/core": "^0.21.2",
+		"@types/node": "^24.12.2",
+		"nano-staged": "^1.0.2",
+		"playwright": "^1.59.1",
+		"simple-git-hooks": "^2.13.1",
+		"typescript": "^6.0.3"
+	},
+	"peerDependencies": {
+		"@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+	},
+	"peerDependenciesMeta": {
+		"@rsbuild/core": {
+			"optional": true
+		}
+	},
+	"packageManager": "pnpm@10.33.0",
+	"publishConfig": {
+		"access": "public",
+		"registry": "https://registry.npmjs.org/"
+	}
 }

--- a/rslib.config.ts
+++ b/rslib.config.ts
@@ -1,19 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-	lib: [
-		{ syntax: 'es2021', dts: true },
-		{
-			format: 'cjs',
-			syntax: 'es2021',
-			output: {
-				externals: {
-					toml: 'import toml',
-				},
-			},
-		},
-	],
-	output: {
-		target: 'node',
-	},
+	lib: [{ syntax: 'es2023', dts: true }],
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,15 @@
 {
-  "compilerOptions": {
-    "rootDir": "./src",
-    "outDir": "./dist",
-    "target": "ES2023",
-    "types": ["node"],
-    "lib": ["DOM", "ESNext"],
-    "declaration": true,
-    "isolatedModules": true,
-    "skipLibCheck": true,
-    "module": "nodenext",
-    "moduleResolution": "nodenext"
-  },
-  "include": ["src"]
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist",
+		"target": "ES2023",
+		"types": ["node"],
+		"lib": ["DOM", "ESNext"],
+		"declaration": true,
+		"isolatedModules": true,
+		"skipLibCheck": true,
+		"module": "nodenext",
+		"moduleResolution": "nodenext"
+	},
+	"include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Simplify the Rslib config to emit a single ESM build with ES2023 syntax and declaration files.
- Align `package.json` exports with the generated output by removing the legacy CommonJS and duplicate entry fields.